### PR TITLE
Fixed the import for GQLBoosters inside GQLPattern

### DIFF
--- a/src/models/GQLPattern.ts
+++ b/src/models/GQLPattern.ts
@@ -1,5 +1,5 @@
 import {None, Option} from 'funfix';
-import {GQLFieldBooster} from './GQLFieldBooster';
+import {GQLFieldBooster} from './GQLBooster';
 
 interface IGQLPattern {
     field: string;

--- a/src/models/_t/GQLPattern.ts
+++ b/src/models/_t/GQLPattern.ts
@@ -1,0 +1,18 @@
+import { expect } from 'chai';
+import { List, Map } from 'immutable';
+import 'mocha';
+import {GQLGeoNearFeaturePattern} from '../GQLPattern';
+import Namespace from '../Namespace';
+
+describe('GQLPatterns -> GQLGeoNearFeaturePattern', () => {
+    const GQLNearFeaturePattern = new GQLGeoNearFeaturePattern('fieldArg', 'SomeFeature', 'km', 500);
+    it('Should contain all properties', () => {
+        expect(GQLNearFeaturePattern).to.have.keys('field', 'feature', 'distance', 'units');
+    });
+    it('Should all properties be set to proper values', () => {
+        expect(GQLNearFeaturePattern.field).to.eql('fieldArg');
+        expect(GQLNearFeaturePattern.feature).to.eql('SomeFeature');
+        expect(GQLNearFeaturePattern.units).to.eql('km');
+        expect(GQLNearFeaturePattern.distance).to.eql(500);
+    });
+});


### PR DESCRIPTION
I've left the testing file inside, I though we could do that, add the fixes with the testing scripts on the fly instead of adding testing files individually. 