### PR TITLE
Tweak public API abstraction 

### DIFF
--- a/src/Resolver.ts
+++ b/src/Resolver.ts
@@ -1,4 +1,4 @@
-import { None, Option } from 'funfix';
+import { None, Some } from 'funfix';
 import { Map } from 'immutable';
 import { Builder } from './builders/Builder';
 import { GQLQueryBuilder } from './builders/graphql/GQLQueryBuilder';
@@ -14,10 +14,14 @@ export class Resolver {
 
   public resolve(
     query: string,
-    vars: Map<string, any> = Map<string, any>(),
-    operationName: Option<string> = None
+    vars: { [key: string]: any } = {},
+    operationName: string = ''
   ) {
-    const queryBuilder = new GQLQueryBuilder(this.context, vars, operationName);
+    const queryBuilder = new GQLQueryBuilder(
+      this.context,
+      Map(vars),
+      operationName ? Some(operationName) : None
+    );
     return Builder.parse<GQLQueryDocument>(queryBuilder, query).map(doc =>
       doc.execute(queryBuilder)
     );

--- a/src/models/ResolverContext.ts
+++ b/src/models/ResolverContext.ts
@@ -6,7 +6,7 @@ import { GQLSchema } from './GQLSchema';
 
 interface IResolverCtxParams {
   schema: string;
-  strategies: {};
+  strategies: { [key: string]: QueryStrategyFactory };
   defaultStrategy: string;
 }
 

--- a/src/strategies/SparqlQueryStrategyFactory.ts
+++ b/src/strategies/SparqlQueryStrategyFactory.ts
@@ -17,6 +17,9 @@ export class SparqlQueryStrategyFactory extends QueryStrategyFactory {
 
   constructor(params: ISparqlQueryStrategyFactoryParams) {
     super();
+    if (!params.endpoint) {
+      throw new URIError('SPARQL endpoint URL must not be empty!');
+    }
     this.endpoint = params.endpoint;
     const prefixesSN: Map<string, SimpleNamespace> = Map(
       params.prefixes.map<[string, SimpleNamespace]>(([prefix, url]) => [

--- a/src/strategies/SparqlQueryStrategyFactory.ts
+++ b/src/strategies/SparqlQueryStrategyFactory.ts
@@ -6,15 +6,20 @@ import { SimpleNamespace } from '../models/Namespace';
 import { QueryStrategyFactory } from './QueryStrategyFactory';
 import { SparqlQueryStrategy } from './SparqlQueryStrategy';
 
+interface ISparqlQueryStrategyFactoryParams {
+  endpoint: string;
+  prefixes: Array<[string, string]>;
+}
+
 export class SparqlQueryStrategyFactory extends QueryStrategyFactory {
   public endpoint: string;
   public prefixes: Map<string, SimpleNamespace>;
 
-  constructor(endpoint: string, prefixes: Array<[string, string]> = []) {
+  constructor(params: ISparqlQueryStrategyFactoryParams) {
     super();
-    this.endpoint = endpoint;
+    this.endpoint = params.endpoint;
     const prefixesSN: Map<string, SimpleNamespace> = Map(
-      prefixes.map<[string, SimpleNamespace]>(([prefix, url]) => [
+      params.prefixes.map<[string, SimpleNamespace]>(([prefix, url]) => [
         prefix,
         new SimpleNamespace(prefix, url),
       ])


### PR DESCRIPTION
Tweaked the params for `SparqlQueryStrategyFactory` to be an object with 2 params, `endpoint` and `prefixes`.  Other than this, the abstraction seems to adhere to the specs provided in the README. Resolves #39 